### PR TITLE
Is it a bug

### DIFF
--- a/config/initializers/show_full_fields.rb
+++ b/config/initializers/show_full_fields.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |_, _, _, _, payload|
+  sql = payload[:sql]
+
+  if sql.include?("SHOW FULL FIELDS")
+    puts "SHOW FULL FIELDS queries are not allowed"
+  end
+end


### PR DESCRIPTION
#### eager_load true

```
$ DATABASE_URL="trilogy://root@127.0.0.1:60950" RAILS_EAGER_LOAD=true bin/rails c
Loading development environment (Rails 7.1.3.2)
irb(main):001> Post.last & Bing.last
  Post Load (0.8ms)  SELECT `posts`.* FROM `posts` ORDER BY `posts`.`id` DESC LIMIT 1
  Bing Load (0.7ms)  SELECT `bings`.* FROM `bings` ORDER BY `bings`.`id` DESC LIMIT 1
=> false
irb(main):002>
```

#### eager_load true & lazily_load_schema_cache true

```
$ DATABASE_URL="trilogy://root@127.0.0.1:60950" RAILS_EAGER_LOAD=true LAZILY_LOAD_SCHEMA_CACHE=true bin/rails c
Loading development environment (Rails 7.1.3.2)
irb(main):001> Post.last & Bing.last
  Post Load (0.2ms)  SELECT `posts`.* FROM `posts` ORDER BY `posts`.`id` DESC LIMIT 1
  Bing Load (0.2ms)  SELECT `bings`.* FROM `bings` ORDER BY `bings`.`id` DESC LIMIT 1
=> false
irb(main):002>
```

#### eager_load true & schema_cache_dump true

```
$ DATABASE_URL="trilogy://root@127.0.0.1:60950" RAILS_EAGER_LOAD=true SCHEMA_CACHE_DUMP=true bin/rails c
Loading development environment (Rails 7.1.3.2)
irb(main):001> Post.last & Bing.last
  ActiveRecord::SchemaMigration Load (0.3ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
  Post Load (0.8ms)  SELECT `posts`.* FROM `posts` ORDER BY `posts`.`id` DESC LIMIT 1
  ActiveRecord::SchemaMigration Load (0.3ms)  SELECT `schema_migrations`.`version` FROM `schema_migrations` ORDER BY `schema_migrations`.`version` ASC
  Bing Load (0.5ms)  SELECT `bings`.* FROM `bings` ORDER BY `bings`.`id` DESC LIMIT 1
=> false
irb(main):002>
```